### PR TITLE
現在の利用 Ruby バージョン範囲内に収めるよう、octokit のバージョンを固定した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ruby:2.6.5-alpine3.10
 
 RUN apk add --no-cache git tzdata
-RUN gem install git-pr-release -v "0.8.0"
+RUN gem install octokit -v "4.25.1" && \
+    gem install git-pr-release -v "0.8.0"
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
以下のようなエラーが出て本 git-pr-release-action の Docker イメージ作成に失敗していました。

> Step 3/5 : RUN gem install git-pr-release -v "0.8.0"
>   ---> Running in 40e0717d7da8
> ERROR:  Error installing git-pr-release:
>   	The last version of octokit (>= 0) to support your Ruby & RubyGems was 4.25.1. Try installing it with `gem install octokit -v 4.25.1` and then running the current command again
>   	octokit requires Ruby version >= 2.7.0. The current ruby version is 2.6.5.114.

https://github.com/crowdport/funds-embulk-etl/runs/7313166039?check_suite_focus=true

上記エラーの指示内容通り、Ruby 2.6 でもサポートするバージョンに octokit を下げます。