### PR TITLE
現在の利用 Ruby バージョン範囲内に収めるよう、依存ライブラリのバージョンを固定した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ruby:2.6.5-alpine3.10
 
 RUN apk add --no-cache git tzdata
-RUN gem install octokit -v "4.25.1" && \
+RUN gem install highline -v 2.1.0 && \
+    gem install faraday-net_http -v 3.0.2 && \
+    gem install faraday -v 2.8.1 && \
+    gem install octokit -v "4.25.1" && \
     gem install git-pr-release -v "0.8.0"
-
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## 対応内容

現在の利用 Ruby バージョン範囲内に収めるよう、依存ライブラリのバージョンを固定しました。

## PR 文脈

https://crowdport.slack.com/archives/CGWUE0M71/p1704940854064289

## 検証結果

Docker イメージのビルドに成功しています

```
docker build -t git-pr-release-action:test .

[+] Building 87.1s (9/9) FINISHED                                                                                                                                                                                         docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 408B                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ruby:2.6.5-alpine3.10                                                                                                                                                             1.3s
 => [1/4] FROM docker.io/library/ruby:2.6.5-alpine3.10@sha256:fe938308542059d2df4be11183bd2b45a3ab16e5d30f861dd9d97326438eca2a                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                                    0.0s
 => => transferring context: 72B                                                                                                                                                                                                     0.0s
 => CACHED [2/4] RUN apk add --no-cache git tzdata                                                                                                                                                                                   0.0s
 => [3/4] RUN gem install highline -v 2.1.0 &&     gem install faraday-net_http -v 3.0.2 &&     gem install faraday -v 2.8.1 &&     gem install octokit -v "4.25.1" &&     gem install git-pr-release -v "0.8.0"                    85.6s
 => [4/4] ADD entrypoint.sh /entrypoint.sh                                                                                                                                                                                           0.0s
 => exporting to image                                                                                                                                                                                                               0.1s
 => => exporting layers                                                                                                                                                                                                              0.1s
 => => writing image sha256:36823584b8d94e184c2bd9855c6ab662b6f0ecb74926d71889ac42f7dcd06897                                                                                                                                         0.0s
 => => naming to docker.io/library/git-pr-release-action:test                                                                                                                                                                        0.0s
```