### PR TITLE
public_suffix のバージョンを Ruby 2.6 系のものに固定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM ruby:2.6.5-alpine3.10
 
 RUN apk add --no-cache git tzdata
-RUN gem install highline -v 2.1.0 && \
-    gem install faraday-net_http -v 3.0.2 && \
-    gem install faraday -v 2.8.1 && \
-    gem install octokit -v "4.25.1" && \
-    gem install git-pr-release -v "0.8.0"
+RUN gem install \
+        'highline:2.1.0' \
+        'faraday-net_http:3.0.2' \
+        'faraday:2.8.1' \
+        'public_suffix:5.1.1' \
+        'octokit:4.25.1' \
+        'git-pr-release:0.8.0'
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
marketplace-server の git-pr-release が以下エラーで失敗していました。

> 93.44 ERROR:  Error installing octokit:
> 93.44 	The last version of public_suffix (>= 2.0.2, < 7.0) to support your Ruby & RubyGems was 5.1.1. Try installing it with `gem install public_suffix -v 5.1.1` and then running the current command again

https://github.com/crowdport/marketplace-server/actions/runs/9643285940/job/26592930988

いい加減 Ruby 3 系にしろという話かもしれませんがいったんこれで。。

## 手元での docker build

手元で docker build が成功したことを確認しています。

``` console
docker build -t git-pr-release-action:test .

[+] Building 110.7s (9/9) FINISHED                                                                                                                                                                                        docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 360B                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/ruby:2.6.5-alpine3.10                                                                                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                                                      0.0s
 => [1/4] FROM docker.io/library/ruby:2.6.5-alpine3.10                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                    0.0s
 => => transferring context: 72B                                                                                                                                                                                                     0.0s
 => CACHED [2/4] RUN apk add --no-cache git tzdata                                                                                                                                                                                   0.0s
 => [3/4] RUN gem install         'highline:2.1.0'         'faraday-net_http:3.0.2'         'faraday:2.8.1'         'public_suffix:5.1.1'         'octokit:4.25.1'         'git-pr-release:0.8.0'                                  110.4s
 => [4/4] ADD entrypoint.sh /entrypoint.sh                                                                                                                                                                                           0.1s
 => exporting to image                                                                                                                                                                                                               0.1s
 => => exporting layers                                                                                                                                                                                                              0.1s
 => => writing image sha256:6d024395a9a7a88da4392dd62ab19bb884b06219f8cb79593321b339abd49abb                                                                                                                                         0.0s
 => => naming to docker.io/library/git-pr-release-action:test     
```